### PR TITLE
Admin email on confirm_track_sub execution.

### DIFF
--- a/YOUR_ADMIN/confirm_track_sub.php
+++ b/YOUR_ADMIN/confirm_track_sub.php
@@ -188,6 +188,11 @@ The following items have shipped:
 
 
                 zen_mail($email_to, $email_to, $subject, $message, STORE_NAME, EMAIL_FROM, $html_msg, NULL);
+
+                //send extra emails
+                if (SEND_EXTRA_ORDERS_STATUS_ADMIN_EMAILS_TO_STATUS == '1' and SEND_EXTRA_ORDERS_STATUS_ADMIN_EMAILS_TO != '') {
+                  zen_mail('', SEND_EXTRA_ORDERS_STATUS_ADMIN_EMAILS_TO, $subject, $message, STORE_NAME, EMAIL_FROM, $html_msg, NULL);
+                }
             } else {
                 $customer_notified = 0;
             }


### PR DESCRIPTION
If so configured, send email to site  admin when a sub sets
tracking number(s) for an order.
